### PR TITLE
Fix segfault in extent test

### DIFF
--- a/safe/gui/tools/test/test_extent_selector.py
+++ b/safe/gui/tools/test/test_extent_selector.py
@@ -56,13 +56,6 @@ class ExtentSelectorTest(unittest.TestCase):
 
         self.dialog.extent_defined.connect(self.extent_defined)
 
-        self.widget = QtWidgets.QWidget()
-        self.widget.setGeometry(0, 0, 500, 500)
-        layout = QtWidgets.QVBoxLayout(self.widget)
-        layout.addWidget(CANVAS)
-        self.widget.show()
-        QTest.qWaitForWindowExposed(self.widget)
-
         self.dialog.show()
         QTest.qWaitForWindowExposed(self.dialog)
 
@@ -90,9 +83,6 @@ class ExtentSelectorTest(unittest.TestCase):
         """Slot for when the mouse moves on the canvas."""
         # print point.toString()
 
-
-    # FIXME: This currently segfaults on Travis
-    @unittest.skipIf(os.environ.get('ON_TRAVIS', False), "This currently segfaults on Travis")
     def test_spinboxes(self):
         """Test validate extent method."""
         self.dialog.x_maximum.clear()


### PR DESCRIPTION
Don't reparent canvas to a temporary widget -- doing so causes the canvas to be deleted when the test cleans up, resulting in a segfault
