### PR TITLE
Fix help not showing in MacOS.

### DIFF
--- a/safe/utilities/help.py
+++ b/safe/utilities/help.py
@@ -39,6 +39,8 @@ def show_help(message=None):
     """
 
     help_path = mktemp('.html')
-    with open(help_path, 'w+') as f:
-        f.write(get_help_html(message))
-        QDesktopServices.openUrl(QUrl(help_path))
+    with open(help_path, 'wb+') as f:
+        help_html = get_help_html(message)
+        f.write(help_html.encode('utf8'))
+        path_with_protocol = 'file://' + help_path
+        QDesktopServices.openUrl(QUrl(path_with_protocol))


### PR DESCRIPTION

![fix_help](https://user-images.githubusercontent.com/1421861/41592572-34fb15fc-73e7-11e8-9f03-597524d16cc6.gif)

It seems we need to add the protocol manually in MacOS to make it work and convert to Unicode first (plus us wb+)